### PR TITLE
Add a container-based development environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,13 @@ To run, the following environment variables are required:
   * `DISCORD_TOKEN`: Your Discord API token.
   * `CHANNEL_ID`: The Discord Channel ID to join when someone else joins.
   * `GUILD_ID`: The Discord Guild ID being connected to.
+
+
+## Development environment
+
+If you are so inclined, there is a Dockerfile and some helper scripts in the ```devel/``` folder
+that you may find to be handy for development. The scripts assume you have
+[podman](https://podman.io/) installed. You can use ```build.sh``` to build a development container,
+and you can use ```cargo.sh``` to run Rust's [cargo](https://doc.rust-lang.org/cargo/) tool inside
+the container. You can probably guess what ```test.sh``` does, if you are somebody's kid and are
+smart.

--- a/devel/Dockerfile
+++ b/devel/Dockerfile
@@ -1,0 +1,31 @@
+FROM registry.fedoraproject.org/fedora:32
+
+RUN dnf install -y https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-32.noarch.rpm
+RUN dnf install -y \
+	autoconf \
+	cargo \
+	clippy \
+	diffutils \
+	ffmpeg \
+	file \
+	findutils \
+	libsodium-devel \
+	make \
+	openssl-devel \
+	opus-devel \
+	sqlite-devel \
+	xz
+
+RUN mkdir /root/deep_speech
+RUN curl -L https://github.com/mozilla/DeepSpeech/releases/download/v0.7.0/native_client.amd64.cpu.linux.tar.xz -o /root/deep_speech/deep_speech.tar.xz
+RUN cd /root/deep_speech && tar xvf deep_speech.tar.xz
+RUN mv /root/deep_speech/libdeepspeech.so /usr/lib64/
+
+# This way we can cache all the build dependencies
+RUN cd /devel && cargo build
+# This way we can cache all the development dependencies
+RUN cd /devel && cargo test
+# This way we can cache all the doc dependencies
+RUN cd /devel && cargo doc
+
+CMD ["bash"]

--- a/devel/build.sh
+++ b/devel/build.sh
@@ -1,0 +1,6 @@
+#! /usr/bin/bash
+
+SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. && pwd)"
+
+podman build --pull -t btfm:dev -v $SRC_DIR:/devel:z --force-rm=true \
+	-f devel/Dockerfile

--- a/devel/cargo.sh
+++ b/devel/cargo.sh
@@ -1,0 +1,7 @@
+#! /usr/bin/bash
+
+SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. && pwd)"
+PARAMS=$@
+
+podman run --net=host --rm -it -v $SRC_DIR:/devel:z btfm:dev \
+	bash -c "cd /devel && cargo $PARAMS"

--- a/devel/test.sh
+++ b/devel/test.sh
@@ -1,0 +1,8 @@
+#! /usr/bin/bash
+
+SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. && pwd)"
+PARAMS=$@
+
+podman run --rm -it -v $SRC_DIR:/devel:z \
+	-e RUST_BACKTRACE=1 btfm:dev \
+	bash -c "cd /devel && cargo test && cargo clippy --all-targets --all-features -- -D warnings && cargo doc && cargo fmt -- --check -v"


### PR DESCRIPTION
There is now a Dockerfile that installs btfm's dependencies and
builds it, runs its tests, and builds its docs (the last three
enable the resulting container to cache all the built
dependencies).

There are also some helper scripts that use podman for common
tasks, such as building the image, running cargo, or running the
tests.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>