### PR TITLE
Set DATABASE_URL to an absolute temporary path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
           sudo cp libdeepspeech.so /usr/local/lib/
           sudo ldconfig
           sudo apt install -y libsqlite3-dev
+          export DATABASE_URL=sqlite://"$(mktemp -d)"/test.sqlite
+          echo "DATABASE_URL=$DATABASE_URL" >> $GITHUB_ENV
           cargo install sqlx-cli
           cargo sqlx database setup
       - uses: actions-rs/cargo@v1
@@ -66,6 +68,8 @@ jobs:
           sudo cp libdeepspeech.so /usr/local/lib/
           sudo ldconfig
           sudo apt install -y libsqlite3-dev
+          export DATABASE_URL=sqlite://"$(mktemp -d)"/test.sqlite
+          echo "DATABASE_URL=$DATABASE_URL" >> $GITHUB_ENV
           cargo install sqlx-cli
           cargo sqlx database setup
       - uses: actions-rs/cargo@v1
@@ -86,6 +90,8 @@ jobs:
           sudo cp libdeepspeech.so /usr/local/lib/
           sudo ldconfig
           sudo apt install -y libsqlite3-dev
+          export DATABASE_URL=sqlite://"$(mktemp -d)"/test.sqlite
+          echo "DATABASE_URL=$DATABASE_URL" >> $GITHUB_ENV
           cargo install sqlx-cli
           cargo sqlx database setup
       - uses: actions-rs/cargo@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
           sudo ldconfig
           sudo apt install -y libsqlite3-dev
           export DATABASE_URL=sqlite://"$(mktemp -d)"/test.sqlite
+          echo "DATABASE_URL=$DATABASE_URL" >> $GITHUB_ENV
           cargo install sqlx-cli
           cargo sqlx database setup
       - name: Create release build


### PR DESCRIPTION
cargo-publish zips up the source and unpacks it elsewhere to make sure
it builds, but with sqlx we need a database set up to validate queries
against. Set up a database in a tempdir and reference it by absolute
path so the publish job can find it.